### PR TITLE
Juan menu order items

### DIFF
--- a/api/models/menu_items.py
+++ b/api/models/menu_items.py
@@ -1,15 +1,17 @@
-from sqlalchemy import Column, ForeignKey, Integer, String, DECIMAL, DATETIME
+from sqlalchemy import Column, Integer, String, Float
 from sqlalchemy.orm import relationship
-from datetime import datetime
 from ..dependencies.database import Base
 
 
-class Sandwich(Base):
-    __tablename__ = "sandwiches"
+class MenuItem(Base):
+    __tablename__ = "menu_items"
 
     id = Column(Integer, primary_key=True, index=True, autoincrement=True)
-    sandwich_name = Column(String(100), unique=True, nullable=True)
-    price = Column(DECIMAL(4, 2), nullable=False, server_default='0.0')
+    name = Column(String, nullable=False)
+    description = Column(String, nullable=True)
+    price = Column(Float, nullable=False)
+    calories = Column(Integer, nullable=True)
+    category = Column(String, nullable=True)
 
-    recipes = relationship("Recipe", back_populates="sandwich")
-    order_details = relationship("OrderDetail", back_populates="sandwich")
+    order_items = relationship("OrderItem", back_populates="menu_item")
+    reviews = relationship("Review", back_populates="menu_item")

--- a/api/models/model_loader.py
+++ b/api/models/model_loader.py
@@ -1,4 +1,14 @@
-from . import orders, order_details, customers, menu_items, resources, promotions, reviews, payments
+from . import (
+    orders,
+    order_details,
+    customers,
+    menu_items,
+    order_items,
+    resources,
+    promotions,
+    reviews,
+    payments
+)
 
 from ..dependencies.database import engine
 
@@ -8,6 +18,7 @@ def index():
     order_details.Base.metadata.create_all(engine)
     customers.Base.metadata.create_all(engine)
     menu_items.Base.metadata.create_all(engine)
+    order_items.Base.metadata.create_all(engine)
     resources.Base.metadata.create_all(engine)
     #promotions.Base.metadata.create_all(engine)
     reviews.Base.metadata.create_all(engine)

--- a/api/models/order_items.py
+++ b/api/models/order_items.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Integer, ForeignKey
+from sqlalchemy.orm import relationship
+from ..dependencies.database import Base
+
+
+class OrderItem(Base):
+    __tablename__ = "order_items"
+
+    id = Column(Integer, primary_key=True, index=True)
+    order_id = Column(Integer, ForeignKey("orders.id"), nullable=False)
+    menu_item_id = Column(Integer, ForeignKey("menu_items.id"), nullable=False)
+    quantity = Column(Integer, nullable=False)
+
+    order = relationship("Order", back_populates="order_items")
+    menu_item = relationship("MenuItem", back_populates="order_items")

--- a/api/models/orders.py
+++ b/api/models/orders.py
@@ -18,3 +18,5 @@ class Order(Base):
     order_details = relationship("OrderDetail", back_populates="order", cascade="all, delete")
     payment = relationship("Payment", back_populates="order", uselist=False)
     promotions = relationship("Promotion", back_populates="order")
+
+    order_items = relationship("OrderItem", back_populates="order")

--- a/api/models/reviews.py
+++ b/api/models/reviews.py
@@ -10,3 +10,7 @@ class Review(Base):
     order_id = Column(Integer, ForeignKey("orders.id"), nullable=False)
     rating = Column(Integer, nullable=False)
     comment = Column(String(255), nullable=True)
+
+    menu_item_id = Column(Integer, ForeignKey("menu_items.id"), nullable=False)
+    menu_item = relationship("MenuItem", back_populates="reviews")
+

--- a/api/schemas/menu_items.py
+++ b/api/schemas/menu_items.py
@@ -1,24 +1,21 @@
-from datetime import datetime
-from typing import Optional
 from pydantic import BaseModel
+from typing import Optional
 
 
-class SandwichBase(BaseModel):
-    sandwich_name: str
+class MenuItemBase(BaseModel):
+    name: str
+    description: Optional[str] = None
     price: float
+    calories: Optional[int] = None
+    category: Optional[str] = None
 
 
-class SandwichCreate(SandwichBase):
+class MenuItemCreate(MenuItemBase):
     pass
 
 
-class SandwichUpdate(BaseModel):
-    sandwich_name: Optional[str] = None
-    price: Optional[float] = None
-
-
-class Sandwich(SandwichBase):
+class MenuItem(MenuItemBase):
     id: int
 
-    class ConfigDict:
-        from_attributes = True
+    class Config:
+        orm_mode = True

--- a/api/schemas/order_items.py
+++ b/api/schemas/order_items.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+
+
+class OrderItemBase(BaseModel):
+    order_id: int
+    menu_item_id: int
+    quantity: int
+
+
+class OrderItemCreate(OrderItemBase):
+    pass
+
+
+class OrderItem(OrderItemBase):
+    id: int
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
- Added SQLAlchemy model and Pydantic schema for MenuItem
- Added SQLAlchemy model and Pydantic schema for OrderItem (join table between Order and MenuItem)
- Updated model_loader.py to register both models so their tables are created
- Added relationship links in models/orders.py and models/reviews.py for model connections

- I noticed payments and promotions are still commented out in model_loader.py — flagging for the team to confirm if they're ready